### PR TITLE
Fixing headers for reading public ORCID records.

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -149,8 +149,8 @@ class Provider extends AbstractProvider
                         $userUrl,
                         [RequestOptions::HEADERS => ['Content-Type' => 'application/vnd.orcid+xml',
                             'Accept'                                => 'application/json',
-                            'Authorization type'                    => 'Bearer',
-                            'Access token'                          => $token, ],
+                            'Authorization'                         => 'Bearer ' . $token,
+                            ],
                         ]
                     );
 


### PR DESCRIPTION
PHP 8.1.3
laravel/framework 9.8.1
guzzlehttp/guzzle 7.4.2
socialiteproviders/orcid 5.0.0

The original header configuration with header names “Authorization type” and “Access token” lets guzzlehttp throw this error:

“"Authorization type" is not valid header name”

See https://github.com/guzzle/psr7/blob/master/src/MessageTrait.php, lines 227-234.

The correct syntax of the Authorization header is according to developer.mozilla.org in the case of OAuth 2.0 the following:

Authorization: Bearer <token>

See:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization#syntax
https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#authentication_schemes

This seems to be related to the ORCID documentation which unfortunately contains some, to say the least, mistakable information like for example here:
https://info.orcid.org/documentation/api-tutorials/api-tutorial-read-data-on-a-record/#easy-faq-2570

It is also worth noting (although beyond the scope of this pull request) that calls to read an ORCID record via the “Public API” using the “/authenticate” scope really don't need the token at all, which can easily be proven, see:
https://groups.google.com/g/orcid-api-users/c/0gXLWIxi9GU/m/mMqBfp3DAgAJ
However that behavior may of course be fixed in the future. The header name misconception in the ORCID documentation is addressed in the Google groups thread as well.